### PR TITLE
Add contribution guidelines and PR template.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+The **Dogmatiq** organization maintains open source software; contributions from
+the community are encouraged and very much appreciated. Please take a moment to
+read these guidelines before submitting changes.
+
+Contributions to our projects are released under the MIT license, unless
+stated otherwise by the project's LICENSE file.
+
+## Building and testing
+
+With few exceptions, all of our repositories include a Makefile designed for use
+with GNU make. Running `make` with no arguments always runs the tests.
+
+## Submitting a pull request
+
+Before submitting your pull request, please open a GitHub issue on the relevant
+project to discuss the change you'd like to make. If there is an existing issue
+please discuss the changes there to clarify the approach that should be taken.
+
+Some further actions you can take that will increase the likelihood of your pull
+request being accepted include:
+
+- Mimicking the code style and quality of the project.
+- Including unit tests. Use the existing tools used throughout the project.
+- Submit small, focussed PRs. If you have multiple unrelated changes please
+  submit them as separate PRs. Avoid correcting unrelated typos and code style
+  violations within more substantial PRs.
+- Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## Resources
+
+- [Dogmatiq Community Health Documents](https://github.com/dogmatiq/.github)
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using GitHub Pull Requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ request being accepted include:
   submit them as separate PRs. Avoid correcting unrelated typos and code style
   violations within more substantial PRs.
 - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Adding any substantial API or behavioral changes to CHANGELOG.md under an
+  `[Unreleased]` heading at the top of the file.
 
 ## Resources
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,9 @@ Example: Allow for compaction of projections.
 
 BEFORE YOU SUBMIT A PULL REQUEST:
 
-- Read the contribution guidelines.
+- Read the contribution guidelines at https://github.com/dogmatiq/.github/CONTRIBUTING.md.
 - Know what you are submitting.
 - Review the entire diff line-by-line. If this is too hard, your PR is too big.
-- Add your changes to the CHANGELOG.md file. Add an [Unreleased] section at the
-  top of the file if there isn't one already.
 
 ------------------------------------------------------------------------------->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,8 @@ BEFORE YOU SUBMIT A PULL REQUEST:
 - Read the contribution guidelines.
 - Know what you are submitting.
 - Review the entire diff line-by-line. If this is too hard, your PR is too big.
+- Add your changes to the CHANGELOG.md file. Add an [Unreleased] section at the
+  top of the file if there isn't one already.
 
 ------------------------------------------------------------------------------->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -51,14 +51,6 @@ the lifetime of their projection data, which might otherwise go unaddressed.
 
 -->
 
-#### What approach has been taken?
-
-<!-- Example:
-
-A `Compact()` method has been added to the `ProjectionMessageHandler` interface.
-
--->
-
 #### Is there anything you are unsure about?
 
 <!-- Example:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,68 @@
+<!------------------------------------------------------------------------------
+
+A GOOD PULL REQUEST:
+
+- Is small.
+- Contains a single change that makes sense in isolation.
+- Makes the code better.
+
+
+A GOOD PULL REQUEST TITLE:
+
+- Completes the sentence "If applied, this PR will ...".
+- Is less than 50 characters.
+
+Example: Allow for compaction of projections.
+
+
+BEFORE YOU SUBMIT A PULL REQUEST:
+
+- Read the contribution guidelines.
+- Know what you are submitting.
+- Review the entire diff line-by-line. If this is too hard, your PR is too big.
+
+------------------------------------------------------------------------------->
+
+#### What change does this introduce?
+
+<!-- Example:
+
+This PR adds support for "projection compaction", which is an operation on
+projections that can be invoked by the engine to clean up any "unused" or
+"oversized" projection data.
+
+-->
+
+#### What issues does this relate to?
+
+<!-- Example:
+
+Fixes #123
+Partially addresses #456
+
+-->
+
+#### Why make this change?
+
+<!-- Example:
+
+By making this a first-class feature we encourage the developer to think about
+the lifetime of their projection data, which might otherwise go unaddressed.
+
+-->
+
+#### What approach has been taken?
+
+<!-- Example:
+
+A `Compact()` method has been added to the `ProjectionMessageHandler` interface.
+
+-->
+
+#### Is there anything you are unsure about?
+
+<!-- Example:
+
+Should `Compact()` impose its own timeout?
+
+-->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -43,7 +43,7 @@ projections that can be invoked by the engine to clean up any "unused" or
 <!--
 
 Link to any GitHub issues that are relevant to these changes. Use the "fixes"
-keyword if you believe an issue to be completely address by this PR.
+keyword if you believe an issue to be completely addressed by this PR.
 
 -- EXAMPLE:
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,9 +25,14 @@ BEFORE YOU SUBMIT A PULL REQUEST:
 
 #### What change does this introduce?
 
-<!-- Example:
+<!--
 
-This PR adds support for "projection compaction", which is an operation on
+Briefly describe the change you've made in terms of the features or behavior it
+introduces or modifies.
+
+-- EXAMPLE:
+
+This PR adds support for "projection compaction" which is an operation on
 projections that can be invoked by the engine to clean up any "unused" or
 "oversized" projection data.
 
@@ -35,7 +40,12 @@ projections that can be invoked by the engine to clean up any "unused" or
 
 #### What issues does this relate to?
 
-<!-- Example:
+<!--
+
+Link to any GitHub issues that are relevant to these changes. Use the "fixes"
+keyword if you believe an issue to be completely address by this PR.
+
+-- EXAMPLE:
 
 Fixes #123
 Partially addresses #456
@@ -44,7 +54,11 @@ Partially addresses #456
 
 #### Why make this change?
 
-<!-- Example:
+<!--
+
+Briefly describe the rationale behind making this change.
+
+-- EXAMPLE
 
 By making this a first-class feature we encourage the developer to think about
 the lifetime of their projection data, which might otherwise go unaddressed.
@@ -53,8 +67,16 @@ the lifetime of their projection data, which might otherwise go unaddressed.
 
 #### Is there anything you are unsure about?
 
-<!-- Example:
+<!--
 
-Should `Compact()` impose its own timeout?
+This is a place to ask any specific questions about the changes you've made that
+you'd like to see addressed by the project's maintainers before they begin
+reviewing.
+
+Consider submitting a draft PR if you require feedback about incomplete changes.
+
+-- EXAMPLE
+
+Should `Compact()` implementations be required to impose their own timeout?
 
 -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# .github
-Dogmatiq community health files.
+# Dogmatiq Community Health Files
+
+This repository contains the GitHub "community health" files for the Dogmatiq
+organisation.


### PR DESCRIPTION
#### What change does this introduce?

Adds `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md`.

#### What issues does this relate to?

Partially addresses https://github.com/dogmatiq/dogma/issues/19

#### Why make this change?

To help people who which to contribute to Dogmatiq projection understand how to do so effectively.

#### What approach has been taken?

Authored markdown files as per [GitHub's instructions](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-default-community-health-file).

#### Is there anything you are unsure about?

Because these are default files that apply to all Dogmatiq projects it's hard to provide too much concrete information about how to build and test each project. I do feel like these files at least point in the right direction.