### PR TITLE
Move PR template guide to the CONTRIBUTING.md file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,58 @@ request being accepted include:
 
 - Mimicking the code style and quality of the project.
 - Including unit tests. Use the existing tools used throughout the project.
-- Submit small, focussed PRs. If you have multiple unrelated changes please
+- Submitting small, focussed PRs. If you have multiple unrelated changes please
   submit them as separate PRs. Avoid correcting unrelated typos and code style
-  violations within more substantial PRs.
-- Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
-- Adding any substantial API or behavioral changes to CHANGELOG.md under an
+  violations within more substantial PRs. Review the diff line-by-line. If this
+  is too hard, your PR is too big.
+- Writing [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Adding any user-facing API or behavioral changes to CHANGELOG.md under an
   `[Unreleased]` heading at the top of the file.
+- Using a PR title that completes the sentence "If applied, this PR will ...".
+- Completing each section of the pull-request template.
+
+### Pull request template
+
+This pull request template contains several prompts for information. Each prompt
+is described below along with an example answer.
+
+**Prompt:** *What change does this introduce?*
+
+Briefly describe the change you've made in terms of the features or behavior it
+introduces or modifies.
+
+Example:
+> This PR adds support for "projection compaction" which is an operation on
+> projections that can be invoked by the engine to clean up any "unused" or
+> "oversized" projection data.
+
+**Prompt:** *Why make this change?*
+
+Briefly describe the rationale behind making this change.
+
+Example:
+> By making this a first-class feature we encourage the developer to think about
+> the lifetime of their projection data, which might otherwise go unaddressed.
+
+**Prompt:** *Is there anything you are unsure about?*
+
+This is a place to ask any specific questions about the changes you've made that
+you'd like to see addressed by the project's maintainers before they begin
+reviewing.
+
+Consider submitting a draft PR if you require feedback about incomplete changes.
+
+Example:
+> Should `Compact()` implementations be required to impose their own timeout?
+
+**Prompt:** *What issues does this relate to?*
+
+Link to any GitHub issues that are relevant to these changes. Use the "fixes"
+keyword if you believe an issue to be completely addressed by this PR.
+
+Example:
+> - Fixes #123
+> - Partially addresses #456
 
 ## Resources
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,82 +1,22 @@
-<!------------------------------------------------------------------------------
+<!--
+A complete guide to completing the pull request template is available at
+https://github.com/dogmatiq/.github/CONTRIBUTING.md.
 
-A GOOD PULL REQUEST:
-
-- Is small.
-- Contains a single change that makes sense in isolation.
-- Makes the code better.
-
-
-A GOOD PULL REQUEST TITLE:
-
-- Completes the sentence "If applied, this PR will ...".
-- Is less than 50 characters.
-
-Example: Allow for compaction of projections.
-
-
-BEFORE YOU SUBMIT A PULL REQUEST:
-
-- Read the contribution guidelines at https://github.com/dogmatiq/.github/CONTRIBUTING.md.
-- Know what you are submitting.
-- Review the entire diff line-by-line. If this is too hard, your PR is too big.
-
-------------------------------------------------------------------------------->
+Don't forget to update the CHANGELOG.md file! :)
+-->
 
 #### What change does this introduce?
 
-<!--
-
-Briefly describe the change you've made in terms of the features or behavior it
-introduces or modifies.
-
--- EXAMPLE:
-
-This PR adds support for "projection compaction" which is an operation on
-projections that can be invoked by the engine to clean up any "unused" or
-"oversized" projection data.
-
--->
-
-#### What issues does this relate to?
-
-<!--
-
-Link to any GitHub issues that are relevant to these changes. Use the "fixes"
-keyword if you believe an issue to be completely addressed by this PR.
-
--- EXAMPLE:
-
-Fixes #123
-Partially addresses #456
-
--->
+...
 
 #### Why make this change?
 
-<!--
-
-Briefly describe the rationale behind making this change.
-
--- EXAMPLE
-
-By making this a first-class feature we encourage the developer to think about
-the lifetime of their projection data, which might otherwise go unaddressed.
-
--->
+...
 
 #### Is there anything you are unsure about?
 
-<!--
+...
 
-This is a place to ask any specific questions about the changes you've made that
-you'd like to see addressed by the project's maintainers before they begin
-reviewing.
+#### What issues does this relate to?
 
-Consider submitting a draft PR if you require feedback about incomplete changes.
-
--- EXAMPLE
-
-Should `Compact()` implementations be required to impose their own timeout?
-
--->
+...


### PR DESCRIPTION
#### What change does this introduce?

This PR moves the bulk of the comments in the PR template into the CONTRIBUTING.md file.

The top of the PR template now provides a link to the CONTRIBUTING.md file and a reminder to update the CHANGELOG.md file.

I've also moved the `What issues does this relate to?` section to the bottom.

#### What issues does this relate to?

None

#### Why make this change?

As discussed with @danilvpetrov and @koden-km, it's annoying to search through the template looking for the headings and to remove the comments.

#### Is there anything you are unsure about?

No