### PR TITLE
fix contributing link in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 A complete guide to completing the pull request template is available at
-https://github.com/dogmatiq/.github/CONTRIBUTING.md.
+https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.
 
 Don't forget to update the CHANGELOG.md file! :)
 -->


### PR DESCRIPTION
#### What change does this introduce?

Fix link to [CONTRIBUTING.md](https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md)

#### Why make this change?

The current link is not found.

#### Is there anything you are unsure about?

Not really, figured it's a typo and wasn't tested.

#### What issues does this relate to?

None, figured it was simple enough for a PR skipping the issue.
